### PR TITLE
Added callback for EntrypointObjC

### DIFF
--- a/ios/EntrypointObjC.h
+++ b/ios/EntrypointObjC.h
@@ -14,7 +14,7 @@
 -(void)setUrl:(NSString*)scheme url:(NSString*)url port:(NSNumber*)port;
 -(void)setTransactionInfo:(NSString*)contract_account action:(NSString*)action permissionAccount:(NSString*)permissionAccount permissionType:(NSString*)permissionType privateKeyString:(NSString*)privateKeyString;
 -(void)setMessage:(NSString*)message;
--(void)pushAction;
+-(void)pushAction:(RCTResponseSenderBlock)success failure:(RCTResponseSenderBlock)failure;
 
 @end
 

--- a/ios/EntrypointObjC.m
+++ b/ios/EntrypointObjC.m
@@ -18,6 +18,11 @@
 #else
 #import <React/RCTLog.h>
 #endif
+#if __has_include("RCTEventDispatcher.h")
+#import "RCTEventDispatcher.h"
+#else
+#import <React/RCTEventDispatcher.h>
+#endif
 
 @implementation EntrypointObjC
 
@@ -55,9 +60,19 @@ NSString *_privateKeyString;
     _message = message;
 }
 
--(void)pushAction
+-(void)pushAction:(RCTResponseSenderBlock)success failure:(RCTResponseSenderBlock)failure
 {
-    [entrypoint pushActionObjC:_contract_account action:_action message:_message permissionAccount:_permissionAccount permissionType:_permissionType privateKeyString:_privateKeyString callback:^(NSString* response) { RCTLogInfo(@"%@", [NSString stringWithFormat:@"RCTBackgroundGeolocation Chain Response: %@", response]); }];
+    [entrypoint pushActionObjC:_contract_account action:_action message:_message permissionAccount:_permissionAccount permissionType:_permissionType privateKeyString:_privateKeyString callback:^(NSString* response) {
+        if ([response rangeOfString:@"Blockchain error"].location == NSNotFound) {
+            if (success != nil) {
+                success(@[response]);
+            }
+        } else {
+            if (failure != nil) {
+                failure(@[response]);
+            }
+        }
+    }];
 }
  
 @end


### PR DESCRIPTION
In order for other modules to receive responses from the blockchain, I added the possibility for success/failure callbacks on the objC interface of the module for iOS.

Java already works since it already works with promises.

Note: This update will break the current background-geolocation-module since the module does not send the 2 extra required parameters.

This request should be merged at the same time as this one:

https://github.com/raphaelgodro/background-geolocation-chain/pull/5